### PR TITLE
Give Block's Stmt* a name

### DIFF
--- a/grammar/stmt.lyg
+++ b/grammar/stmt.lyg
@@ -5,4 +5,4 @@ Stmt =
   | Semi:";"
   ;
 
-Block = "{" attrs:InnerAttr* Stmt* "}";
+Block = "{" attrs:InnerAttr* stmts:Stmt* "}";


### PR DESCRIPTION
We probably want to be able to access this.

cc @Centril, noticed in #30