### PR TITLE
Update gll and grammer.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,5 +33,5 @@ name = "snapshots"
 path = "src/bin/snapshots.rs"
 
 [patch.'crates-io']
-gll = { git = "https://github.com/rust-lang/gll", rev = "617ecfc58a554c92226ec276063c99a09678fb05" }
-grammer = { git = "https://github.com/lykenware/grammer", rev = "eb47b51a9332c0e82d7c02d988e203d2a01f3654" }
+gll = { git = "https://github.com/rust-lang/gll", rev = "26d42a0117b9c48538ef20c872742e05070bb55e" }
+grammer = { git = "https://github.com/lykenware/grammer", rev = "6f6f1320336d84b75805907fb302a28cb6d4cfb0" }

--- a/build.rs
+++ b/build.rs
@@ -17,9 +17,9 @@ fn main() {
         .filter(|entry| entry.path().extension().map_or(false, |ext| ext == "lyg"));
 
     // Start with the builtin rules for proc-macro grammars.
-    let mut cx = gll::proc_macro::Context::new();
+    let mut cx = gll::grammer::proc_macro::Context::new();
     let cx = &mut cx;
-    let mut grammar = gll::proc_macro::builtin(cx);
+    let mut grammar = gll::grammer::proc_macro::builtin(cx);
 
     // Add in each grammar fragment to the grammar.
     for fragment in fragments {

--- a/src/bin/snapshots.rs
+++ b/src/bin/snapshots.rs
@@ -9,15 +9,13 @@ use {
     walkdir::WalkDir,
 };
 
-fn parse_result_to_str<T: Debug>(
-    mut result: Result<T, gll::parser::ParseError<proc_macro2::Span>>,
-) -> String {
-    if let Err(error) = &mut result {
-        // HACK(eddyb) this is inefficient - `expected` should be already
-        // sorted for us, so this is a temporary workaround.
-        error.expected.sort_by_cached_key(|x| format!("{:?}", x));
-    }
+type ProcMacroPat =
+    gll::grammer::proc_macro::Pat<&'static [gll::grammer::proc_macro::FlatTokenPat<&'static str>]>;
 
+fn parse_result_to_str<T: Debug>(
+    result: Result<T, gll::grammer::parser::ParseError<proc_macro2::Span, ProcMacroPat>>,
+) -> String {
+    // FIXME(eddyb) print the location properly in case of error.
     format!("{:#?}", result)
 }
 

--- a/src/bin/snapshots/snapshots__Expr.arithmetic.input.snap
+++ b/src/bin/snapshots/snapshots__Expr.arithmetic.input.snap
@@ -1,5 +1,5 @@
 ---
-created: "2019-05-23T21:43:46.053084Z"
+created: "2019-08-25T01:01:25.355353066Z"
 creator: insta@0.7.4
 source: src/bin/snapshots.rs
 expression: forest
@@ -8,35 +8,35 @@ Ok(
     Expr {
         attrs: [],
         kind: ExprKind::Binary {
-            op: BinaryOp::Mul,
             left: Expr {
                 attrs: [],
                 kind: ExprKind::Literal,
             },
+            op: BinaryOp::Mul,
             right: Expr {
                 attrs: [],
                 kind: ExprKind::Binary {
-                    op: BinaryOp::Add,
                     left: Expr {
                         attrs: [],
                         kind: ExprKind::Literal,
                     },
+                    op: BinaryOp::Add,
                     right: Expr {
                         attrs: [],
                         kind: ExprKind::Binary {
-                            op: BinaryOp::Div,
                             left: Expr {
                                 attrs: [],
                                 kind: ExprKind::Literal,
                             },
+                            op: BinaryOp::Div,
                             right: Expr {
                                 attrs: [],
                                 kind: ExprKind::Binary {
+                                    left: Expr {
+                                        attrs: [],
+                                        kind: ExprKind::Literal,
+                                    },
                                     op: BinaryOp::Sub,
-                                    left: Expr {
-                                        attrs: [],
-                                        kind: ExprKind::Literal,
-                                    },
                                     right: Expr {
                                         attrs: [],
                                         kind: ExprKind::Literal,
@@ -44,21 +44,21 @@ Ok(
                                 },
                             },
                         } | ExprKind::Binary {
-                            op: BinaryOp::Sub,
                             left: Expr {
                                 attrs: [],
                                 kind: ExprKind::Binary {
-                                    op: BinaryOp::Div,
                                     left: Expr {
                                         attrs: [],
                                         kind: ExprKind::Literal,
                                     },
+                                    op: BinaryOp::Div,
                                     right: Expr {
                                         attrs: [],
                                         kind: ExprKind::Literal,
                                     },
                                 },
                             },
+                            op: BinaryOp::Sub,
                             right: Expr {
                                 attrs: [],
                                 kind: ExprKind::Literal,
@@ -66,29 +66,29 @@ Ok(
                         },
                     },
                 } | ExprKind::Binary {
-                    op: BinaryOp::Div,
                     left: Expr {
                         attrs: [],
                         kind: ExprKind::Binary {
-                            op: BinaryOp::Add,
                             left: Expr {
                                 attrs: [],
                                 kind: ExprKind::Literal,
                             },
+                            op: BinaryOp::Add,
                             right: Expr {
                                 attrs: [],
                                 kind: ExprKind::Literal,
                             },
                         },
                     },
+                    op: BinaryOp::Div,
                     right: Expr {
                         attrs: [],
                         kind: ExprKind::Binary {
-                            op: BinaryOp::Sub,
                             left: Expr {
                                 attrs: [],
                                 kind: ExprKind::Literal,
                             },
+                            op: BinaryOp::Sub,
                             right: Expr {
                                 attrs: [],
                                 kind: ExprKind::Literal,
@@ -96,23 +96,22 @@ Ok(
                         },
                     },
                 } | ExprKind::Binary {
-                    op: BinaryOp::Sub,
                     left: Expr {
                         attrs: [],
                         kind: ExprKind::Binary {
-                            op: BinaryOp::Add,
                             left: Expr {
                                 attrs: [],
                                 kind: ExprKind::Literal,
                             },
+                            op: BinaryOp::Add,
                             right: Expr {
                                 attrs: [],
                                 kind: ExprKind::Binary {
-                                    op: BinaryOp::Div,
                                     left: Expr {
                                         attrs: [],
                                         kind: ExprKind::Literal,
                                     },
+                                    op: BinaryOp::Div,
                                     right: Expr {
                                         attrs: [],
                                         kind: ExprKind::Literal,
@@ -120,27 +119,28 @@ Ok(
                                 },
                             },
                         } | ExprKind::Binary {
-                            op: BinaryOp::Div,
                             left: Expr {
                                 attrs: [],
                                 kind: ExprKind::Binary {
-                                    op: BinaryOp::Add,
                                     left: Expr {
                                         attrs: [],
                                         kind: ExprKind::Literal,
                                     },
+                                    op: BinaryOp::Add,
                                     right: Expr {
                                         attrs: [],
                                         kind: ExprKind::Literal,
                                     },
                                 },
                             },
+                            op: BinaryOp::Div,
                             right: Expr {
                                 attrs: [],
                                 kind: ExprKind::Literal,
                             },
                         },
                     },
+                    op: BinaryOp::Sub,
                     right: Expr {
                         attrs: [],
                         kind: ExprKind::Literal,
@@ -148,37 +148,37 @@ Ok(
                 },
             },
         } | ExprKind::Binary {
+            left: Expr {
+                attrs: [],
+                kind: ExprKind::Binary {
+                    left: Expr {
+                        attrs: [],
+                        kind: ExprKind::Literal,
+                    },
+                    op: BinaryOp::Mul,
+                    right: Expr {
+                        attrs: [],
+                        kind: ExprKind::Literal,
+                    },
+                },
+            },
             op: BinaryOp::Add,
-            left: Expr {
-                attrs: [],
-                kind: ExprKind::Binary {
-                    op: BinaryOp::Mul,
-                    left: Expr {
-                        attrs: [],
-                        kind: ExprKind::Literal,
-                    },
-                    right: Expr {
-                        attrs: [],
-                        kind: ExprKind::Literal,
-                    },
-                },
-            },
             right: Expr {
                 attrs: [],
                 kind: ExprKind::Binary {
-                    op: BinaryOp::Div,
                     left: Expr {
                         attrs: [],
                         kind: ExprKind::Literal,
                     },
+                    op: BinaryOp::Div,
                     right: Expr {
                         attrs: [],
                         kind: ExprKind::Binary {
+                            left: Expr {
+                                attrs: [],
+                                kind: ExprKind::Literal,
+                            },
                             op: BinaryOp::Sub,
-                            left: Expr {
-                                attrs: [],
-                                kind: ExprKind::Literal,
-                            },
                             right: Expr {
                                 attrs: [],
                                 kind: ExprKind::Literal,
@@ -186,21 +186,21 @@ Ok(
                         },
                     },
                 } | ExprKind::Binary {
-                    op: BinaryOp::Sub,
                     left: Expr {
                         attrs: [],
                         kind: ExprKind::Binary {
-                            op: BinaryOp::Div,
                             left: Expr {
                                 attrs: [],
                                 kind: ExprKind::Literal,
                             },
+                            op: BinaryOp::Div,
                             right: Expr {
                                 attrs: [],
                                 kind: ExprKind::Literal,
                             },
                         },
                     },
+                    op: BinaryOp::Sub,
                     right: Expr {
                         attrs: [],
                         kind: ExprKind::Literal,
@@ -208,23 +208,22 @@ Ok(
                 },
             },
         } | ExprKind::Binary {
-            op: BinaryOp::Div,
             left: Expr {
                 attrs: [],
                 kind: ExprKind::Binary {
-                    op: BinaryOp::Mul,
                     left: Expr {
                         attrs: [],
                         kind: ExprKind::Literal,
                     },
+                    op: BinaryOp::Mul,
                     right: Expr {
                         attrs: [],
                         kind: ExprKind::Binary {
-                            op: BinaryOp::Add,
                             left: Expr {
                                 attrs: [],
                                 kind: ExprKind::Literal,
                             },
+                            op: BinaryOp::Add,
                             right: Expr {
                                 attrs: [],
                                 kind: ExprKind::Literal,
@@ -232,35 +231,36 @@ Ok(
                         },
                     },
                 } | ExprKind::Binary {
-                    op: BinaryOp::Add,
                     left: Expr {
                         attrs: [],
                         kind: ExprKind::Binary {
-                            op: BinaryOp::Mul,
                             left: Expr {
                                 attrs: [],
                                 kind: ExprKind::Literal,
                             },
+                            op: BinaryOp::Mul,
                             right: Expr {
                                 attrs: [],
                                 kind: ExprKind::Literal,
                             },
                         },
                     },
+                    op: BinaryOp::Add,
                     right: Expr {
                         attrs: [],
                         kind: ExprKind::Literal,
                     },
                 },
             },
+            op: BinaryOp::Div,
             right: Expr {
                 attrs: [],
                 kind: ExprKind::Binary {
-                    op: BinaryOp::Sub,
                     left: Expr {
                         attrs: [],
                         kind: ExprKind::Literal,
                     },
+                    op: BinaryOp::Sub,
                     right: Expr {
                         attrs: [],
                         kind: ExprKind::Literal,
@@ -268,31 +268,30 @@ Ok(
                 },
             },
         } | ExprKind::Binary {
-            op: BinaryOp::Sub,
             left: Expr {
                 attrs: [],
                 kind: ExprKind::Binary {
-                    op: BinaryOp::Mul,
                     left: Expr {
                         attrs: [],
                         kind: ExprKind::Literal,
                     },
+                    op: BinaryOp::Mul,
                     right: Expr {
                         attrs: [],
                         kind: ExprKind::Binary {
-                            op: BinaryOp::Add,
                             left: Expr {
                                 attrs: [],
                                 kind: ExprKind::Literal,
                             },
+                            op: BinaryOp::Add,
                             right: Expr {
                                 attrs: [],
                                 kind: ExprKind::Binary {
+                                    left: Expr {
+                                        attrs: [],
+                                        kind: ExprKind::Literal,
+                                    },
                                     op: BinaryOp::Div,
-                                    left: Expr {
-                                        attrs: [],
-                                        kind: ExprKind::Literal,
-                                    },
                                     right: Expr {
                                         attrs: [],
                                         kind: ExprKind::Literal,
@@ -300,21 +299,21 @@ Ok(
                                 },
                             },
                         } | ExprKind::Binary {
-                            op: BinaryOp::Div,
                             left: Expr {
                                 attrs: [],
                                 kind: ExprKind::Binary {
-                                    op: BinaryOp::Add,
                                     left: Expr {
                                         attrs: [],
                                         kind: ExprKind::Literal,
                                     },
+                                    op: BinaryOp::Add,
                                     right: Expr {
                                         attrs: [],
                                         kind: ExprKind::Literal,
                                     },
                                 },
                             },
+                            op: BinaryOp::Div,
                             right: Expr {
                                 attrs: [],
                                 kind: ExprKind::Literal,
@@ -322,29 +321,29 @@ Ok(
                         },
                     },
                 } | ExprKind::Binary {
-                    op: BinaryOp::Add,
                     left: Expr {
                         attrs: [],
                         kind: ExprKind::Binary {
-                            op: BinaryOp::Mul,
                             left: Expr {
                                 attrs: [],
                                 kind: ExprKind::Literal,
                             },
+                            op: BinaryOp::Mul,
                             right: Expr {
                                 attrs: [],
                                 kind: ExprKind::Literal,
                             },
                         },
                     },
+                    op: BinaryOp::Add,
                     right: Expr {
                         attrs: [],
                         kind: ExprKind::Binary {
-                            op: BinaryOp::Div,
                             left: Expr {
                                 attrs: [],
                                 kind: ExprKind::Literal,
                             },
+                            op: BinaryOp::Div,
                             right: Expr {
                                 attrs: [],
                                 kind: ExprKind::Literal,
@@ -352,23 +351,22 @@ Ok(
                         },
                     },
                 } | ExprKind::Binary {
-                    op: BinaryOp::Div,
                     left: Expr {
                         attrs: [],
                         kind: ExprKind::Binary {
-                            op: BinaryOp::Mul,
                             left: Expr {
                                 attrs: [],
                                 kind: ExprKind::Literal,
                             },
+                            op: BinaryOp::Mul,
                             right: Expr {
                                 attrs: [],
                                 kind: ExprKind::Binary {
-                                    op: BinaryOp::Add,
                                     left: Expr {
                                         attrs: [],
                                         kind: ExprKind::Literal,
                                     },
+                                    op: BinaryOp::Add,
                                     right: Expr {
                                         attrs: [],
                                         kind: ExprKind::Literal,
@@ -376,33 +374,35 @@ Ok(
                                 },
                             },
                         } | ExprKind::Binary {
-                            op: BinaryOp::Add,
                             left: Expr {
                                 attrs: [],
                                 kind: ExprKind::Binary {
-                                    op: BinaryOp::Mul,
                                     left: Expr {
                                         attrs: [],
                                         kind: ExprKind::Literal,
                                     },
+                                    op: BinaryOp::Mul,
                                     right: Expr {
                                         attrs: [],
                                         kind: ExprKind::Literal,
                                     },
                                 },
                             },
+                            op: BinaryOp::Add,
                             right: Expr {
                                 attrs: [],
                                 kind: ExprKind::Literal,
                             },
                         },
                     },
+                    op: BinaryOp::Div,
                     right: Expr {
                         attrs: [],
                         kind: ExprKind::Literal,
                     },
                 },
             },
+            op: BinaryOp::Sub,
             right: Expr {
                 attrs: [],
                 kind: ExprKind::Literal,

--- a/src/bin/snapshots/snapshots__GenericArgs.binding-before-lifetime.error.input.snap
+++ b/src/bin/snapshots/snapshots__GenericArgs.binding-before-lifetime.error.input.snap
@@ -1,5 +1,5 @@
 ---
-created: "2019-08-24T22:44:34.221417271Z"
+created: "2019-08-25T01:01:24.667388914Z"
 creator: insta@0.7.4
 source: src/bin/snapshots.rs
 expression: forest
@@ -8,19 +8,8 @@ Err(
     ParseError {
         at: Span,
         expected: [
-            [
-                Ident(
-                    None,
-                ),
-            ],
-            [
-                Punct {
-                    ch: Some(
-                        '>',
-                    ),
-                    joint: None,
-                },
-            ],
+            IDENT,
+            ">",
         ],
     },
 )

--- a/src/bin/snapshots/snapshots__GenericArgs.binding-before-type.error.input.snap
+++ b/src/bin/snapshots/snapshots__GenericArgs.binding-before-type.error.input.snap
@@ -1,6 +1,6 @@
 ---
-created: "2019-06-02T15:47:35.207485Z"
-creator: insta@0.8.1
+created: "2019-08-25T01:01:21.976069615Z"
+creator: insta@0.7.4
 source: src/bin/snapshots.rs
 expression: forest
 ---
@@ -8,14 +8,7 @@ Err(
     ParseError {
         at: Span,
         expected: [
-            [
-                Punct {
-                    ch: Some(
-                        '=',
-                    ),
-                    joint: None,
-                },
-            ],
+            "=",
         ],
     },
 )

--- a/src/bin/snapshots/snapshots__GenericArgs.comma.error.input.snap
+++ b/src/bin/snapshots/snapshots__GenericArgs.comma.error.input.snap
@@ -1,5 +1,5 @@
 ---
-created: "2019-08-24T22:44:34.272568062Z"
+created: "2019-08-25T02:12:18.716683672Z"
 creator: insta@0.7.4
 source: src/bin/snapshots.rs
 expression: forest
@@ -8,169 +8,25 @@ Err(
     ParseError {
         at: Span,
         expected: [
-            [
-                Delim(
-                    '(',
-                ),
-            ],
-            [
-                Delim(
-                    '(',
-                ),
-            ],
-            [
-                Delim(
-                    '(',
-                ),
-            ],
-            [
-                Delim(
-                    '[',
-                ),
-            ],
-            [
-                Delim(
-                    '[',
-                ),
-            ],
-            [
-                Ident(
-                    None,
-                ),
-            ],
-            [
-                Ident(
-                    Some(
-                        "_",
-                    ),
-                ),
-            ],
-            [
-                Ident(
-                    Some(
-                        "dyn",
-                    ),
-                ),
-            ],
-            [
-                Ident(
-                    Some(
-                        "extern",
-                    ),
-                ),
-            ],
-            [
-                Ident(
-                    Some(
-                        "fn",
-                    ),
-                ),
-            ],
-            [
-                Ident(
-                    Some(
-                        "for",
-                    ),
-                ),
-            ],
-            [
-                Ident(
-                    Some(
-                        "impl",
-                    ),
-                ),
-            ],
-            [
-                Ident(
-                    Some(
-                        "typeof",
-                    ),
-                ),
-            ],
-            [
-                Ident(
-                    Some(
-                        "unsafe",
-                    ),
-                ),
-            ],
-            [
-                Punct {
-                    ch: Some(
-                        '!',
-                    ),
-                    joint: None,
-                },
-            ],
-            [
-                Punct {
-                    ch: Some(
-                        '&',
-                    ),
-                    joint: None,
-                },
-            ],
-            [
-                Punct {
-                    ch: Some(
-                        '*',
-                    ),
-                    joint: None,
-                },
-            ],
-            [
-                Punct {
-                    ch: Some(
-                        ':',
-                    ),
-                    joint: Some(
-                        true,
-                    ),
-                },
-                Punct {
-                    ch: Some(
-                        ':',
-                    ),
-                    joint: None,
-                },
-            ],
-            [
-                Punct {
-                    ch: Some(
-                        '<',
-                    ),
-                    joint: None,
-                },
-            ],
-            [
-                Punct {
-                    ch: Some(
-                        '>',
-                    ),
-                    joint: None,
-                },
-            ],
-            [
-                Punct {
-                    ch: Some(
-                        '?',
-                    ),
-                    joint: None,
-                },
-            ],
-            [
-                Punct {
-                    ch: Some(
-                        '\'',
-                    ),
-                    joint: Some(
-                        true,
-                    ),
-                },
-                Ident(
-                    None,
-                ),
-            ],
+            "(",
+            "[",
+            IDENT,
+            "_",
+            "dyn",
+            "extern",
+            "fn",
+            "for",
+            "impl",
+            "typeof",
+            "unsafe",
+            "!",
+            "&",
+            LIFETIME,
+            "*",
+            "::",
+            "<",
+            ">",
+            "?",
         ],
     },
 )

--- a/src/bin/snapshots/snapshots__GenericArgs.fn-comma.error.input.snap
+++ b/src/bin/snapshots/snapshots__GenericArgs.fn-comma.error.input.snap
@@ -1,5 +1,5 @@
 ---
-created: "2019-08-24T22:44:34.127213707Z"
+created: "2019-08-25T02:12:18.335518347Z"
 creator: insta@0.7.4
 source: src/bin/snapshots.rs
 expression: forest
@@ -8,166 +8,25 @@ Err(
     ParseError {
         at: Span,
         expected: [
-            [
-                Delim(
-                    '(',
-                ),
-            ],
-            [
-                Delim(
-                    '(',
-                ),
-            ],
-            [
-                Delim(
-                    '(',
-                ),
-            ],
-            [
-                Delim(
-                    ')',
-                ),
-            ],
-            [
-                Delim(
-                    '[',
-                ),
-            ],
-            [
-                Delim(
-                    '[',
-                ),
-            ],
-            [
-                Ident(
-                    None,
-                ),
-            ],
-            [
-                Ident(
-                    Some(
-                        "_",
-                    ),
-                ),
-            ],
-            [
-                Ident(
-                    Some(
-                        "dyn",
-                    ),
-                ),
-            ],
-            [
-                Ident(
-                    Some(
-                        "extern",
-                    ),
-                ),
-            ],
-            [
-                Ident(
-                    Some(
-                        "fn",
-                    ),
-                ),
-            ],
-            [
-                Ident(
-                    Some(
-                        "for",
-                    ),
-                ),
-            ],
-            [
-                Ident(
-                    Some(
-                        "impl",
-                    ),
-                ),
-            ],
-            [
-                Ident(
-                    Some(
-                        "typeof",
-                    ),
-                ),
-            ],
-            [
-                Ident(
-                    Some(
-                        "unsafe",
-                    ),
-                ),
-            ],
-            [
-                Punct {
-                    ch: Some(
-                        '!',
-                    ),
-                    joint: None,
-                },
-            ],
-            [
-                Punct {
-                    ch: Some(
-                        '&',
-                    ),
-                    joint: None,
-                },
-            ],
-            [
-                Punct {
-                    ch: Some(
-                        '*',
-                    ),
-                    joint: None,
-                },
-            ],
-            [
-                Punct {
-                    ch: Some(
-                        ':',
-                    ),
-                    joint: Some(
-                        true,
-                    ),
-                },
-                Punct {
-                    ch: Some(
-                        ':',
-                    ),
-                    joint: None,
-                },
-            ],
-            [
-                Punct {
-                    ch: Some(
-                        '<',
-                    ),
-                    joint: None,
-                },
-            ],
-            [
-                Punct {
-                    ch: Some(
-                        '?',
-                    ),
-                    joint: None,
-                },
-            ],
-            [
-                Punct {
-                    ch: Some(
-                        '\'',
-                    ),
-                    joint: Some(
-                        true,
-                    ),
-                },
-                Ident(
-                    None,
-                ),
-            ],
+            "(",
+            ")",
+            "[",
+            IDENT,
+            "_",
+            "dyn",
+            "extern",
+            "fn",
+            "for",
+            "impl",
+            "typeof",
+            "unsafe",
+            "!",
+            "&",
+            LIFETIME,
+            "*",
+            "::",
+            "<",
+            "?",
         ],
     },
 )

--- a/src/bin/snapshots/snapshots__Generics.comma.error.input.snap
+++ b/src/bin/snapshots/snapshots__Generics.comma.error.input.snap
@@ -1,5 +1,5 @@
 ---
-created: "2019-08-24T22:44:33.965415610Z"
+created: "2019-08-25T02:12:18.060129095Z"
 creator: insta@0.7.4
 source: src/bin/snapshots.rs
 expression: forest
@@ -8,40 +8,10 @@ Err(
     ParseError {
         at: Span,
         expected: [
-            [
-                Ident(
-                    None,
-                ),
-            ],
-            [
-                Punct {
-                    ch: Some(
-                        '#',
-                    ),
-                    joint: None,
-                },
-            ],
-            [
-                Punct {
-                    ch: Some(
-                        '>',
-                    ),
-                    joint: None,
-                },
-            ],
-            [
-                Punct {
-                    ch: Some(
-                        '\'',
-                    ),
-                    joint: Some(
-                        true,
-                    ),
-                },
-                Ident(
-                    None,
-                ),
-            ],
+            IDENT,
+            "#",
+            LIFETIME,
+            ">",
         ],
     },
 )

--- a/src/bin/snapshots/snapshots__ModuleContents.hello-world.input.snap
+++ b/src/bin/snapshots/snapshots__ModuleContents.hello-world.input.snap
@@ -1,5 +1,5 @@
 ---
-created: "2019-05-23T21:43:46.020208Z"
+created: "2019-08-25T01:01:24.040844569Z"
 creator: insta@0.7.4
 source: src/bin/snapshots.rs
 expression: forest
@@ -40,6 +40,7 @@ Ok(
                                 Expr {
                                     attrs: [],
                                     kind: ExprKind::Unary {
+                                        op: UnaryOp::Not,
                                         expr: Expr {
                                             attrs: [],
                                             kind: ExprKind::Paren {
@@ -58,7 +59,6 @@ Ok(
                                                 ],
                                             },
                                         },
-                                        op: UnaryOp::Not,
                                     },
                                 },
                             ),

--- a/src/bin/snapshots/snapshots__WhereClause.comma.error.input.snap
+++ b/src/bin/snapshots/snapshots__WhereClause.comma.error.input.snap
@@ -1,5 +1,5 @@
 ---
-created: "2019-08-24T22:44:34.011817302Z"
+created: "2019-08-25T02:12:18.231625946Z"
 creator: insta@0.7.4
 source: src/bin/snapshots.rs
 expression: forest
@@ -8,161 +8,24 @@ Err(
     ParseError {
         at: Span,
         expected: [
-            [
-                Delim(
-                    '(',
-                ),
-            ],
-            [
-                Delim(
-                    '(',
-                ),
-            ],
-            [
-                Delim(
-                    '(',
-                ),
-            ],
-            [
-                Delim(
-                    '[',
-                ),
-            ],
-            [
-                Delim(
-                    '[',
-                ),
-            ],
-            [
-                Ident(
-                    None,
-                ),
-            ],
-            [
-                Ident(
-                    Some(
-                        "_",
-                    ),
-                ),
-            ],
-            [
-                Ident(
-                    Some(
-                        "dyn",
-                    ),
-                ),
-            ],
-            [
-                Ident(
-                    Some(
-                        "extern",
-                    ),
-                ),
-            ],
-            [
-                Ident(
-                    Some(
-                        "fn",
-                    ),
-                ),
-            ],
-            [
-                Ident(
-                    Some(
-                        "for",
-                    ),
-                ),
-            ],
-            [
-                Ident(
-                    Some(
-                        "impl",
-                    ),
-                ),
-            ],
-            [
-                Ident(
-                    Some(
-                        "typeof",
-                    ),
-                ),
-            ],
-            [
-                Ident(
-                    Some(
-                        "unsafe",
-                    ),
-                ),
-            ],
-            [
-                Punct {
-                    ch: Some(
-                        '!',
-                    ),
-                    joint: None,
-                },
-            ],
-            [
-                Punct {
-                    ch: Some(
-                        '&',
-                    ),
-                    joint: None,
-                },
-            ],
-            [
-                Punct {
-                    ch: Some(
-                        '*',
-                    ),
-                    joint: None,
-                },
-            ],
-            [
-                Punct {
-                    ch: Some(
-                        ':',
-                    ),
-                    joint: Some(
-                        true,
-                    ),
-                },
-                Punct {
-                    ch: Some(
-                        ':',
-                    ),
-                    joint: None,
-                },
-            ],
-            [
-                Punct {
-                    ch: Some(
-                        '<',
-                    ),
-                    joint: None,
-                },
-            ],
-            [
-                Punct {
-                    ch: Some(
-                        '?',
-                    ),
-                    joint: None,
-                },
-            ],
-            [
-                Punct {
-                    ch: Some(
-                        '\'',
-                    ),
-                    joint: Some(
-                        true,
-                    ),
-                },
-                Ident(
-                    None,
-                ),
-            ],
+            "(",
+            "[",
+            IDENT,
+            "_",
+            "dyn",
+            "extern",
+            "fn",
+            "for",
+            "impl",
+            "typeof",
+            "unsafe",
+            "!",
+            "&",
+            LIFETIME,
+            "*",
+            "::",
+            "<",
+            "?",
         ],
     },
 )

--- a/src/bin/snapshots/snapshots__WhereClause.for.input.snap
+++ b/src/bin/snapshots/snapshots__WhereClause.for.input.snap
@@ -1,6 +1,6 @@
 ---
-created: "2019-06-02T15:11:48.955334Z"
-creator: insta@0.8.1
+created: "2019-08-25T01:01:22.755527472Z"
+creator: insta@0.7.4
 source: src/bin/snapshots.rs
 expression: forest
 ---
@@ -8,34 +8,6 @@ Ok(
     WhereClause {
         bounds: [
             WhereBound::Type {
-                bounds: [
-                    TypeBound::Trait(
-                        TypeTraitBound {
-                            path: Path {
-                                path: RelativePath {
-                                    segments: [
-                                        PathSegment {
-                                            ident: _,
-                                            args: GenericArgs::AngleBracket {
-                                                args_and_bindings: AngleBracketGenericArgsAndBindings::Args(
-                                                    [
-                                                        GenericArg::Lifetime | GenericArg::Type(
-                                                            Type::DynTrait {
-                                                                bounds: [
-                                                                    TypeBound::Outlives,
-                                                                ],
-                                                            },
-                                                        ),
-                                                    ],
-                                                ),
-                                            },
-                                        },
-                                    ],
-                                },
-                            },
-                        },
-                    ),
-                ],
                 ty: Type::DynTrait {
                     bounds: [
                         TypeBound::Trait(
@@ -65,7 +37,6 @@ Ok(
                         ),
                     ],
                 },
-            } | WhereBound::Type {
                 bounds: [
                     TypeBound::Trait(
                         TypeTraitBound {
@@ -94,6 +65,7 @@ Ok(
                         },
                     ),
                 ],
+            } | WhereBound::Type {
                 binder: ForAllBinder {
                     generics: Generics {
                         params: [
@@ -135,6 +107,34 @@ Ok(
                         ),
                     ],
                 },
+                bounds: [
+                    TypeBound::Trait(
+                        TypeTraitBound {
+                            path: Path {
+                                path: RelativePath {
+                                    segments: [
+                                        PathSegment {
+                                            ident: _,
+                                            args: GenericArgs::AngleBracket {
+                                                args_and_bindings: AngleBracketGenericArgsAndBindings::Args(
+                                                    [
+                                                        GenericArg::Lifetime | GenericArg::Type(
+                                                            Type::DynTrait {
+                                                                bounds: [
+                                                                    TypeBound::Outlives,
+                                                                ],
+                                                            },
+                                                        ),
+                                                    ],
+                                                ),
+                                            },
+                                        },
+                                    ],
+                                },
+                            },
+                        },
+                    ),
+                ],
             },
         ],
     },

--- a/src/bin/snapshots/snapshots__WhereClause.lifetime-multi-t.input.snap
+++ b/src/bin/snapshots/snapshots__WhereClause.lifetime-multi-t.input.snap
@@ -1,5 +1,5 @@
 ---
-created: "2019-06-02T14:39:53.544417Z"
+created: "2019-08-25T01:01:21.891893880Z"
 creator: insta@0.7.4
 source: src/bin/snapshots.rs
 expression: forest
@@ -18,15 +18,15 @@ Ok(
                     },
                 ],
             } | WhereBound::Type {
-                bounds: [
-                    TypeBound::Outlives,
-                    TypeBound::Outlives,
-                ],
                 ty: Type::DynTrait {
                     bounds: [
                         TypeBound::Outlives,
                     ],
                 },
+                bounds: [
+                    TypeBound::Outlives,
+                    TypeBound::Outlives,
+                ],
             },
         ],
     },

--- a/src/bin/snapshots/snapshots__WhereClause.lifetime-multi.input.snap
+++ b/src/bin/snapshots/snapshots__WhereClause.lifetime-multi.input.snap
@@ -1,5 +1,5 @@
 ---
-created: "2019-06-02T14:39:53.613991Z"
+created: "2019-08-25T01:01:25.197432534Z"
 creator: insta@0.7.4
 source: src/bin/snapshots.rs
 expression: forest
@@ -18,15 +18,15 @@ Ok(
                     },
                 ],
             } | WhereBound::Type {
-                bounds: [
-                    TypeBound::Outlives,
-                    TypeBound::Outlives,
-                ],
                 ty: Type::DynTrait {
                     bounds: [
                         TypeBound::Outlives,
                     ],
                 },
+                bounds: [
+                    TypeBound::Outlives,
+                    TypeBound::Outlives,
+                ],
             },
         ],
     },

--- a/src/bin/snapshots/snapshots__WhereClause.lifetime-t.input.snap
+++ b/src/bin/snapshots/snapshots__WhereClause.lifetime-t.input.snap
@@ -1,5 +1,5 @@
 ---
-created: "2019-06-02T14:39:53.519684Z"
+created: "2019-08-25T01:01:24.734027155Z"
 creator: insta@0.7.4
 source: src/bin/snapshots.rs
 expression: forest
@@ -15,14 +15,14 @@ Ok(
                     },
                 ],
             } | WhereBound::Type {
-                bounds: [
-                    TypeBound::Outlives,
-                ],
                 ty: Type::DynTrait {
                     bounds: [
                         TypeBound::Outlives,
                     ],
                 },
+                bounds: [
+                    TypeBound::Outlives,
+                ],
             },
         ],
     },

--- a/src/bin/snapshots/snapshots__WhereClause.lifetime.input.snap
+++ b/src/bin/snapshots/snapshots__WhereClause.lifetime.input.snap
@@ -1,5 +1,5 @@
 ---
-created: "2019-06-02T14:25:33.786617Z"
+created: "2019-08-25T01:01:25.255523987Z"
 creator: insta@0.7.4
 source: src/bin/snapshots.rs
 expression: forest
@@ -15,14 +15,14 @@ Ok(
                     },
                 ],
             } | WhereBound::Type {
-                bounds: [
-                    TypeBound::Outlives,
-                ],
                 ty: Type::DynTrait {
                     bounds: [
                         TypeBound::Outlives,
                     ],
                 },
+                bounds: [
+                    TypeBound::Outlives,
+                ],
             },
         ],
     },

--- a/src/bin/snapshots/snapshots__WhereClause.plus.error.input.snap
+++ b/src/bin/snapshots/snapshots__WhereClause.plus.error.input.snap
@@ -1,5 +1,5 @@
 ---
-created: "2019-08-24T22:44:34.060760871Z"
+created: "2019-08-25T02:12:18.257574113Z"
 creator: insta@0.7.4
 source: src/bin/snapshots.rs
 expression: forest
@@ -8,68 +8,13 @@ Err(
     ParseError {
         at: Span,
         expected: [
-            [
-                Delim(
-                    '(',
-                ),
-            ],
-            [
-                Ident(
-                    None,
-                ),
-            ],
-            [
-                Ident(
-                    Some(
-                        "for",
-                    ),
-                ),
-            ],
-            [
-                Punct {
-                    ch: Some(
-                        ',',
-                    ),
-                    joint: None,
-                },
-            ],
-            [
-                Punct {
-                    ch: Some(
-                        ':',
-                    ),
-                    joint: Some(
-                        true,
-                    ),
-                },
-                Punct {
-                    ch: Some(
-                        ':',
-                    ),
-                    joint: None,
-                },
-            ],
-            [
-                Punct {
-                    ch: Some(
-                        '?',
-                    ),
-                    joint: None,
-                },
-            ],
-            [
-                Punct {
-                    ch: Some(
-                        '\'',
-                    ),
-                    joint: Some(
-                        true,
-                    ),
-                },
-                Ident(
-                    None,
-                ),
-            ],
+            "(",
+            IDENT,
+            "for",
+            LIFETIME,
+            ",",
+            "::",
+            "?",
         ],
     },
 )

--- a/src/bin/snapshots/snapshots__WhereClause.type-multi-t.input.snap
+++ b/src/bin/snapshots/snapshots__WhereClause.type-multi-t.input.snap
@@ -1,6 +1,6 @@
 ---
-created: "2019-06-02T14:56:55.367610Z"
-creator: insta@0.8.1
+created: "2019-08-25T01:01:22.705082793Z"
+creator: insta@0.7.4
 source: src/bin/snapshots.rs
 expression: forest
 ---
@@ -8,34 +8,6 @@ Ok(
     WhereClause {
         bounds: [
             WhereBound::Type {
-                bounds: [
-                    TypeBound::Trait(
-                        TypeTraitBound {
-                            path: Path {
-                                path: RelativePath {
-                                    segments: [
-                                        PathSegment {
-                                            ident: _,
-                                        },
-                                    ],
-                                },
-                            },
-                        },
-                    ),
-                    TypeBound::Trait(
-                        TypeTraitBound {
-                            path: Path {
-                                path: RelativePath {
-                                    segments: [
-                                        PathSegment {
-                                            ident: _,
-                                        },
-                                    ],
-                                },
-                            },
-                        },
-                    ),
-                ],
                 ty: Type::Path(
                     QPath::Unqualified(
                         Path {
@@ -65,6 +37,34 @@ Ok(
                         ),
                     ],
                 },
+                bounds: [
+                    TypeBound::Trait(
+                        TypeTraitBound {
+                            path: Path {
+                                path: RelativePath {
+                                    segments: [
+                                        PathSegment {
+                                            ident: _,
+                                        },
+                                    ],
+                                },
+                            },
+                        },
+                    ),
+                    TypeBound::Trait(
+                        TypeTraitBound {
+                            path: Path {
+                                path: RelativePath {
+                                    segments: [
+                                        PathSegment {
+                                            ident: _,
+                                        },
+                                    ],
+                                },
+                            },
+                        },
+                    ),
+                ],
             },
         ],
     },

--- a/src/bin/snapshots/snapshots__WhereClause.type-multi.input.snap
+++ b/src/bin/snapshots/snapshots__WhereClause.type-multi.input.snap
@@ -1,6 +1,6 @@
 ---
-created: "2019-06-02T14:56:55.406039Z"
-creator: insta@0.8.1
+created: "2019-08-25T01:01:21.824851653Z"
+creator: insta@0.7.4
 source: src/bin/snapshots.rs
 expression: forest
 ---
@@ -8,34 +8,6 @@ Ok(
     WhereClause {
         bounds: [
             WhereBound::Type {
-                bounds: [
-                    TypeBound::Trait(
-                        TypeTraitBound {
-                            path: Path {
-                                path: RelativePath {
-                                    segments: [
-                                        PathSegment {
-                                            ident: _,
-                                        },
-                                    ],
-                                },
-                            },
-                        },
-                    ),
-                    TypeBound::Trait(
-                        TypeTraitBound {
-                            path: Path {
-                                path: RelativePath {
-                                    segments: [
-                                        PathSegment {
-                                            ident: _,
-                                        },
-                                    ],
-                                },
-                            },
-                        },
-                    ),
-                ],
                 ty: Type::Path(
                     QPath::Unqualified(
                         Path {
@@ -65,6 +37,34 @@ Ok(
                         ),
                     ],
                 },
+                bounds: [
+                    TypeBound::Trait(
+                        TypeTraitBound {
+                            path: Path {
+                                path: RelativePath {
+                                    segments: [
+                                        PathSegment {
+                                            ident: _,
+                                        },
+                                    ],
+                                },
+                            },
+                        },
+                    ),
+                    TypeBound::Trait(
+                        TypeTraitBound {
+                            path: Path {
+                                path: RelativePath {
+                                    segments: [
+                                        PathSegment {
+                                            ident: _,
+                                        },
+                                    ],
+                                },
+                            },
+                        },
+                    ),
+                ],
             },
         ],
     },

--- a/src/bin/snapshots/snapshots__WhereClause.type-t.input.snap
+++ b/src/bin/snapshots/snapshots__WhereClause.type-t.input.snap
@@ -1,6 +1,6 @@
 ---
-created: "2019-06-02T14:56:55.314465Z"
-creator: insta@0.8.1
+created: "2019-08-25T01:01:21.552963570Z"
+creator: insta@0.7.4
 source: src/bin/snapshots.rs
 expression: forest
 ---
@@ -8,21 +8,6 @@ Ok(
     WhereClause {
         bounds: [
             WhereBound::Type {
-                bounds: [
-                    TypeBound::Trait(
-                        TypeTraitBound {
-                            path: Path {
-                                path: RelativePath {
-                                    segments: [
-                                        PathSegment {
-                                            ident: _,
-                                        },
-                                    ],
-                                },
-                            },
-                        },
-                    ),
-                ],
                 ty: Type::Path(
                     QPath::Unqualified(
                         Path {
@@ -52,6 +37,21 @@ Ok(
                         ),
                     ],
                 },
+                bounds: [
+                    TypeBound::Trait(
+                        TypeTraitBound {
+                            path: Path {
+                                path: RelativePath {
+                                    segments: [
+                                        PathSegment {
+                                            ident: _,
+                                        },
+                                    ],
+                                },
+                            },
+                        },
+                    ),
+                ],
             },
         ],
     },

--- a/src/bin/snapshots/snapshots__WhereClause.type.input.snap
+++ b/src/bin/snapshots/snapshots__WhereClause.type.input.snap
@@ -1,6 +1,6 @@
 ---
-created: "2019-06-02T14:56:55.228444Z"
-creator: insta@0.8.1
+created: "2019-08-25T01:01:23.474298824Z"
+creator: insta@0.7.4
 source: src/bin/snapshots.rs
 expression: forest
 ---
@@ -8,21 +8,6 @@ Ok(
     WhereClause {
         bounds: [
             WhereBound::Type {
-                bounds: [
-                    TypeBound::Trait(
-                        TypeTraitBound {
-                            path: Path {
-                                path: RelativePath {
-                                    segments: [
-                                        PathSegment {
-                                            ident: _,
-                                        },
-                                    ],
-                                },
-                            },
-                        },
-                    ),
-                ],
                 ty: Type::Path(
                     QPath::Unqualified(
                         Path {
@@ -52,6 +37,21 @@ Ok(
                         ),
                     ],
                 },
+                bounds: [
+                    TypeBound::Trait(
+                        TypeTraitBound {
+                            path: Path {
+                                path: RelativePath {
+                                    segments: [
+                                        PathSegment {
+                                            ident: _,
+                                        },
+                                    ],
+                                },
+                            },
+                        },
+                    ),
+                ],
             },
         ],
     },


### PR DESCRIPTION
* https://github.com/LykenSol/grammer/pull/6 / https://github.com/rust-lang/gll/pull/123 (move everything non-GLL-specific to `grammer`)
* https://github.com/LykenSol/grammer/pull/7 / https://github.com/rust-lang/gll/pull/125 (improve pattern printing for `ParseError`)
* https://github.com/LykenSol/grammer/pull/12 / https://github.com/rust-lang/gll/pull/131 (`ParseError` and pattern fixes, *not merged yet*)