### PR TITLE
Update for new stable and unstable features, and fix a few mistakes.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 **/*.rs.bk
 Cargo.lock
+/.vscode

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,5 +33,5 @@ name = "snapshots"
 path = "src/bin/snapshots.rs"
 
 [patch.'crates-io']
-gll = { git = "https://github.com/rust-lang/gll", rev = "26d42a0117b9c48538ef20c872742e05070bb55e" }
-grammer = { git = "https://github.com/lykenware/grammer", rev = "6f6f1320336d84b75805907fb302a28cb6d4cfb0" }
+gll = { git = "https://github.com/rust-lang/gll", rev = "4c58803c1c4df4ca8798318d63d78454cc4450f6" }
+grammer = { git = "https://github.com/LykenSol/grammer", rev = "eecb1b16cd234408d066fabec63786003925452d" }

--- a/grammar/expr.lyg
+++ b/grammar/expr.lyg
@@ -2,6 +2,8 @@ Expr = attrs:OuterAttr* kind:ExprKind;
 ExprKind =
   | Literal:LITERAL
   | Paren:{ "(" attrs:InnerAttr* expr:Expr ")" }
+  // unstable(raw_ref_op):
+  | RawAddrOf:{ "&" "raw" { "const" | mutable:"mut" } expr:Expr }
   | Borrow:{ "&" mutable:"mut"? expr:Expr }
   | Box:{ "box" expr:Expr }
   | Unary:{ op:UnaryOp expr:Expr }

--- a/grammar/expr.lyg
+++ b/grammar/expr.lyg
@@ -129,4 +129,4 @@ ElseExpr =
 
 MatchArm = attrs:OuterAttr* "|"? pat:Pat { "if" guard:Expr }? "=>" body:Expr ","?;
 
-ClosureArg = pat:Pat { ":" ty:Type }?;
+ClosureArg = attrs:OuterAttr* pat:Pat { ":" ty:Type }?;

--- a/grammar/expr.lyg
+++ b/grammar/expr.lyg
@@ -125,6 +125,6 @@ ElseExpr =
   | If:If
   ;
 
-MatchArm = attrs:OuterAttr* "|"? pats:Pat+ % "|" { "if" guard:Expr }? "=>" body:Expr ","?;
+MatchArm = attrs:OuterAttr* "|"? pat:Pat { "if" guard:Expr }? "=>" body:Expr ","?;
 
 ClosureArg = pat:Pat { ":" ty:Type }?;

--- a/grammar/generics.lyg
+++ b/grammar/generics.lyg
@@ -3,6 +3,8 @@ GenericParam = attrs:OuterAttr* kind:GenericParamKind;
 GenericParamKind =
   | Lifetime:{ name:LIFETIME { ":" bounds:LifetimeBound* %% "+" }? }
   | Type:{ name:IDENT { ":" bounds:TypeBound* %% "+" }? { "=" default:Type }? }
+  // unstable(const_generics):
+  | Const:{ "const" name:IDENT ":" ty:Type }
   ;
 
 ForAllBinder = "for" generics:Generics;
@@ -39,6 +41,8 @@ AngleBracketGenericArgsAndConstraints =
 GenericArg =
   | Lifetime:LIFETIME
   | Type:Type
+  // unstable(const_generics):
+  | Const:{ neg:"-"? lit:LITERAL | "{" expr:Expr "}" }
   ;
 AssocTypeConstraint =
   | Eq:{ name:IDENT "=" ty:Type }

--- a/grammar/generics.lyg
+++ b/grammar/generics.lyg
@@ -23,7 +23,10 @@ TypeBound =
   | Trait:TypeTraitBound
   | TraitParen:{ "(" bound:TypeTraitBound ")" }
   ;
-TypeTraitBound = unbound:"?"? binder:ForAllBinder? path:Path;
+TypeTraitBound =
+  // unstable(const_trait_bound_opt_out):
+  maybe_const:{ "?" "const" }?
+  maybe:"?"? binder:ForAllBinder? path:Path;
 
 // Generic args of a path segment.
 GenericArgs =

--- a/grammar/generics.lyg
+++ b/grammar/generics.lyg
@@ -25,19 +25,22 @@ TypeTraitBound = unbound:"?"? binder:ForAllBinder? path:Path;
 
 // Generic args of a path segment.
 GenericArgs =
-  | AngleBracket:{ "<" args_and_bindings:AngleBracketGenericArgsAndBindings? ">" }
+  | AngleBracket:{ "<" args_and_bindings:AngleBracketGenericArgsAndConstraints? ">" }
   | Paren:{ "(" inputs:Type* %% "," ")" { "->" output:Type }? }
   ;
 
 // FIXME(eddyb) find a way to express this `A* B*` pattern better
-AngleBracketGenericArgsAndBindings =
+AngleBracketGenericArgsAndConstraints =
   | Args:GenericArg+ %% ","
-  | Bindings:TypeBinding+ %% ","
-  | ArgsAndBindings:{ args:GenericArg+ % "," "," bindings:TypeBinding+ %% "," }
+  | Constraints:AssocTypeConstraint+ %% ","
+  | ArgsAndConstraints:{ args:GenericArg+ % "," "," constraints:AssocTypeConstraint+ %% "," }
   ;
 
 GenericArg =
   | Lifetime:LIFETIME
   | Type:Type
   ;
-TypeBinding = name:IDENT "=" ty:Type;
+AssocTypeConstraint =
+  | Eq:{ name:IDENT "=" ty:Type }
+  // unstable(associated_type_bounds):
+  | Bound:{ name:IDENT ":" bounds:TypeBound* %% "+" };

--- a/grammar/item.lyg
+++ b/grammar/item.lyg
@@ -98,10 +98,10 @@ FnParam = attrs:OuterAttr* kind:FnParamKind;
 FnParamKind =
   | SelfValue:{ mutable:"mut"? "self" }
   | SelfRef:{ "&" lt:LIFETIME? mutable:"mut"? "self" }
-  | Regular:FnSigInput
+  | Regular:{ { pat:Pat ":" }? ty:Type }
   ;
 // unstable(c_variadic):
-FnCVariadicParam = { pat:Pat ":" }? "...";
+FnCVariadicParam = attrs:OuterAttr* { pat:Pat ":" }? "...";
 
 EnumVariant = attrs:OuterAttr* name:IDENT kind:EnumVariantKind { "=" discr:Expr }?;
 EnumVariantKind =

--- a/grammar/item.lyg
+++ b/grammar/item.lyg
@@ -33,6 +33,8 @@ ItemKind =
       // unstable(specialization):
       defaultness:"default"?
       unsafety:"unsafe"? "impl" generics:Generics?
+      // unstable(const_trait_impl)
+      constness:"const"?
       { negate:"!"? trait_path:Path "for" }? ty:Type
       where_clause:WhereClause? "{" attrs:InnerAttr* impl_items:ImplItem* "}"
     }

--- a/grammar/item.lyg
+++ b/grammar/item.lyg
@@ -85,15 +85,16 @@ ImplItemKind =
   ;
 
 FnHeader = constness:"const"? unsafety:"unsafe"? asyncness:"async"? { "extern" abi:Abi }?;
-FnDecl = name:IDENT generics:Generics? "(" args:FnArgs? ")" { "->" ret_ty:Type }? where_clause:WhereClause?;
+FnDecl = name:IDENT generics:Generics? "(" params:FnParams? ")" { "->" ret_ty:Type }? where_clause:WhereClause?;
 
 // FIXME(eddyb) find a way to express this `A* B?` pattern better
-FnArgs =
-  | Regular:FnArg+ %% ","
+FnParams =
+  | Regular:FnParam+ %% ","
   | Variadic:"..."
-  | RegularAndVariadic:{ args:FnArg+ % "," "," "..." }
+  | RegularAndVariadic:{ args:FnParam+ % "," "," "..." }
   ;
-FnArg =
+FnParam = attrs:OuterAttr* kind:FnParamKind;
+FnParamKind =
   | SelfValue:{ mutable:"mut"? "self" }
   | SelfRef:{ "&" lt:LIFETIME? mutable:"mut"? "self" }
   | Regular:FnSigInput

--- a/grammar/item.lyg
+++ b/grammar/item.lyg
@@ -90,8 +90,8 @@ FnDecl = name:IDENT generics:Generics? "(" params:FnParams? ")" { "->" ret_ty:Ty
 // FIXME(eddyb) find a way to express this `A* B?` pattern better
 FnParams =
   | Regular:FnParam+ %% ","
-  | Variadic:"..."
-  | RegularAndVariadic:{ args:FnParam+ % "," "," "..." }
+  | CVariadic:FnCVariadicParam
+  | RegularAndCVariadic:{ args:FnParam+ % "," "," c_variadic:FnCVariadicParam }
   ;
 FnParam = attrs:OuterAttr* kind:FnParamKind;
 FnParamKind =
@@ -99,6 +99,8 @@ FnParamKind =
   | SelfRef:{ "&" lt:LIFETIME? mutable:"mut"? "self" }
   | Regular:FnSigInput
   ;
+// unstable(c_variadic):
+FnCVariadicParam = { pat:Pat ":" }? "...";
 
 EnumVariant = attrs:OuterAttr* name:IDENT kind:EnumVariantKind { "=" discr:Expr }?;
 EnumVariantKind =

--- a/grammar/item.lyg
+++ b/grammar/item.lyg
@@ -25,9 +25,8 @@ ItemKind =
     }
   // unstable(trait_alias):
   | TraitAlias:{
-    "trait" name:IDENT generics:Generics?
-        { ":" superbounds:TypeBound* %% "+" }?
-        where_clause:WhereClause? "=" bounds:TypeBound* %% "+" ";"
+      "trait" name:IDENT generics:Generics? "=" bounds:TypeBound* %% "+"
+      where_clause:WhereClause? ";"
     }
   | Impl:{
       // unstable(specialization):

--- a/grammar/item.lyg
+++ b/grammar/item.lyg
@@ -21,7 +21,7 @@ ItemKind =
       auto:"auto"?
       "trait" name:IDENT generics:Generics?
       { ":" superbounds:TypeBound* %% "+" }?
-      where_clause:WhereClause? "{" trait_items:TraitItem* "}"
+      where_clause:WhereClause? "{" attrs:InnerAttr* trait_items:TraitItem* "}"
     }
   // unstable(trait_alias):
   | TraitAlias:{

--- a/grammar/item.lyg
+++ b/grammar/item.lyg
@@ -84,7 +84,7 @@ ImplItemKind =
   | MacroCall:ItemMacroCall
   ;
 
-FnHeader = constness:"const"? unsafety:"unsafe"? asyncness:"async"? { "extern" abi:Abi }?;
+FnHeader = constness:"const"? asyncness:"async"? unsafety:"unsafe"? { "extern" abi:Abi }?;
 FnDecl = name:IDENT generics:Generics? "(" params:FnParams? ")" { "->" ret_ty:Type }? where_clause:WhereClause?;
 
 // FIXME(eddyb) find a way to express this `A* B?` pattern better

--- a/grammar/pat.lyg
+++ b/grammar/pat.lyg
@@ -43,7 +43,8 @@ StructPatFieldsAndEllipsis =
   | FieldsAndEllipsis:{ fields:StructPatField+ % "," "," ".." }
   ;
 
-StructPatField =
+StructPatField = attrs:OuterAttr* kind:StructPatFieldKind;
+StructPatFieldKind =
   | Shorthand:Binding
   | Explicit:{ field:FieldName ":" pat:Pat }
   ;

--- a/grammar/pat.lyg
+++ b/grammar/pat.lyg
@@ -1,18 +1,30 @@
 Pat =
   | Wild:"_"
+  | Rest:".."
   | Literal:{ minus:"-"? lit:LITERAL }
   // unstable(exclusive_range_pattern):
-  | Range:{ start:PatRangeValue ".." end:PatRangeValue }
-  | RangeInclusive:{ start:PatRangeValue { "..." | "..=" } end:PatRangeValue }
+  | Range:{
+    | start:PatRangeValue ".." end:PatRangeValue
+    // unstable(half_open_range_patterns):
+    | start:PatRangeValue ".." | ".." end:PatRangeValue
+  }
+  | RangeInclusive:{
+    | start:PatRangeValue { "..." | "..=" } end:PatRangeValue
+    // unstable(half_open_range_patterns):
+    | { "..." | "..=" } end:PatRangeValue
+  }
   | Binding:{ binding:Binding { "@" subpat:Pat }? }
   | Paren:{ "(" pat:Pat ")" }
   | Ref:{ "&" mutable:"mut"? pat:Pat }
   // unstable(box_patterns):
   | Box:{ "box" pat:Pat }
-  | Slice:{ "[" elems:SlicePatElem* %% "," "]" }
-  | Tuple:{ "(" fields:TuplePatField* %% "," ")" }
+  // unstable(or_patterns):
+  // FIXME(eddyb) find a way to express "2 or more" (like regex `{2,}`).
+  | Or:{ first_pat:Pat "|" pats:Pat+ % "|" }
+  | Slice:{ "[" elems:Pat* %% "," "]" }
+  | Tuple:{ "(" fields:Pat* %% "," ")" }
   | Path:QPath
-  | TupleStruct:{ path:Path "(" fields:TuplePatField* %% "," ")" }
+  | TupleStruct:{ path:Path "(" fields:Pat* %% "," ")" }
   | Struct:{ path:Path "{" fields:StructPatFieldsAndEllipsis "}" }
   | MacroCall:MacroCall
   ;
@@ -23,16 +35,6 @@ PatRangeValue =
   ;
 
 Binding = boxed:"box"? reference:"ref"? mutable:"mut"? name:IDENT;
-
-SlicePatElem =
-  | Subslice:{ subpat:Pat? ".." }
-  | Pat:Pat
-  ;
-
-TuplePatField =
-  | Ellipsis:".."
-  | Pat:Pat
-  ;
 
 // FIXME(eddyb) find a way to express this `A* B?` pattern better
 StructPatFieldsAndEllipsis =

--- a/grammar/type.lyg
+++ b/grammar/type.lyg
@@ -21,7 +21,8 @@ Type =
 
 FnSigInputs =
   | Regular:FnSigInput+ %% ","
-  | CVariadic:"..."
-  | RegularAndCVariadic:{ inputs:FnSigInput+ % "," "," "..." }
+  | CVariadic:FnSigCVariadicInput
+  | RegularAndCVariadic:{ inputs:FnSigInput+ % "," "," c_variadic:FnSigCVariadicInput }
   ;
-FnSigInput = { pat:Pat ":" }? ty:Type;
+FnSigInput = attrs:OuterAttr* { pat:Pat ":" }? ty:Type;
+FnSigCVariadicInput = attrs:OuterAttr* "...";

--- a/grammar/type.lyg
+++ b/grammar/type.lyg
@@ -21,7 +21,7 @@ Type =
 
 FnSigInputs =
   | Regular:FnSigInput+ %% ","
-  | Variadic:"..."
-  | RegularAndVariadic:{ inputs:FnSigInput+ % "," "," "..." }
+  | CVariadic:"..."
+  | RegularAndCVariadic:{ inputs:FnSigInput+ % "," "," "..." }
   ;
 FnSigInput = { pat:Pat ":" }? ty:Type;

--- a/src/bin/coverage.rs
+++ b/src/bin/coverage.rs
@@ -171,7 +171,7 @@ fn ambiguity_check(handle: &ModuleContentsHandle) -> Result<(), MoreThanOne> {
                         add_children(&[child]);
                     }
                 }
-                NodeShape::Choice => add_children(&[forest.one_choice(source)?]),
+                NodeShape::Choice(_) => add_children(&[forest.one_choice(source)?]),
                 NodeShape::Split(..) => {
                     let (left, right) = forest.one_split(source)?;
                     add_children(&[left, right])

--- a/src/bin/snapshots.rs
+++ b/src/bin/snapshots.rs
@@ -57,8 +57,8 @@ fn test_snapshot(file: walkdir::DirEntry) {
         If Cond ElseExpr MatchArm ClosureArg
         // generics.lyg
         Generics GenericParam GenericParamKind ForAllBinder WhereClause WhereBound LifetimeBound
-        TypeBound TypeTraitBound GenericArgs AngleBracketGenericArgsAndBindings GenericArg
-        TypeBinding
+        TypeBound TypeTraitBound GenericArgs AngleBracketGenericArgsAndConstraints GenericArg
+        AssocTypeConstraint
         // item.lyg
         ModuleContents Item ItemKind UseTree UseTreePrefix ForeignItem ForeignItemKind TraitItem
         TraitItemKind ImplItem ImplItemKind FnHeader FnDecl FnArgs FnArg EnumVariant EnumVariantKind

--- a/src/bin/snapshots.rs
+++ b/src/bin/snapshots.rs
@@ -66,8 +66,7 @@ fn test_snapshot(file: walkdir::DirEntry) {
         // macro.lyg
         MacroCall MacroInput ItemMacroCall ItemMacroInput
         // pat.lyg
-        Pat PatRangeValue Binding SlicePatElem TuplePatField StructPatFieldsAndEllipsis
-        StructPatField
+        Pat PatRangeValue Binding StructPatFieldsAndEllipsis StructPatField
         // path.lyg
         Path RelativePath PathSegment QSelf QPath
         // stmt.lyg

--- a/src/bin/snapshots.rs
+++ b/src/bin/snapshots.rs
@@ -61,8 +61,8 @@ fn test_snapshot(file: walkdir::DirEntry) {
         AssocTypeConstraint
         // item.lyg
         ModuleContents Item ItemKind UseTree UseTreePrefix ForeignItem ForeignItemKind TraitItem
-        TraitItemKind ImplItem ImplItemKind FnHeader FnDecl FnArgs FnArg EnumVariant EnumVariantKind
-        StructBody TupleField RecordField
+        TraitItemKind ImplItem ImplItemKind FnHeader FnDecl FnParams FnParam EnumVariant
+        EnumVariantKind StructBody TupleField RecordField
         // macro.lyg
         MacroCall MacroInput ItemMacroCall ItemMacroInput
         // pat.lyg


### PR DESCRIPTION
On rust-lang/rust@b9d5ee567652cd342d9348c215009049551747b0 (w/o submodules), out of a total of 13964 files:

| Before | After | Δ | |
| -: | -: | -: | - |
| 1043 | 1045 | **+2** | parsed fully and unambiguously |
| 12221 | 12534 | **+313** | parsed fully (but ambiguously) |
| 613 | 298 | -315 | parsed partially (only a prefix) |
| 87 | 87 | 0 | didn't parse at all (lexer error?) |

I haven't updated `external/rust` to rust-lang/rust@b9d5ee567652cd342d9348c215009049551747b0, only locally, let me know if I should.

<hr/>

* closes #43 (`const_generics`)
* closes #45 (`c_variadic`)
* closes #46 (parameter attributes)
* closes #57 (struct pattern field attributes)
* closes #62 (swapping `unsafe` and `async`)
* closes #64 (rest patterns)